### PR TITLE
Potential security risk from unsafe external link

### DIFF
--- a/app/views/application/home.html
+++ b/app/views/application/home.html
@@ -5,7 +5,7 @@
 {% if posts %}
   {% for post in posts.items %}
   <div class="row">
-      <span class="title"><a href="{{ post.url }}" target="_blank">{{ post.title }}</a></span>
+      <span class="title"><a href="{{ post.url }}" target="_blank" rel="noopener noreferrer">{{ post.title }}</a></span>
       <span class="owner">{{ post.owner }}</span>
       <span class="source">{{ post.domain }}</span>
       <div class="action">

--- a/app/views/comment/comment.html
+++ b/app/views/comment/comment.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div class="row">
-    <span class="title"><a href="{{ post.url }}" target="_blank">{{ post.title }}</a></span>
+    <span class="title"><a href="{{ post.url }}" target="_blank" rel="noopener noreferrer">{{ post.title }}</a></span>
     <span class="owner">{{ post.owner }}</span>
     <span class="source">{{ post.domain }}</span>
     <hr>


### PR DESCRIPTION
HTML links that open in a new tab or window allow the target page to access the DOM of the origin page using window.opener unless link type noopener or noreferrer is specified. This is a potential security risk. 

References:
- https://mathiasbynens.github.io/rel-noopener/
- https://cwe.mitre.org/data/definitions/1022.html
